### PR TITLE
Resolves flickering in Konsole

### DIFF
--- a/zsh-autocomplete.plugin.zsh
+++ b/zsh-autocomplete.plugin.zsh
@@ -322,7 +322,6 @@ _zsh_autocomplete_c_list_choices() {
   if (( PENDING == 0 && KEYS_QUEUED_COUNT == 0 ))
   then
     local current_word=$PREFIX$SUFFIX
-    zle -M ''
     if (( CURRENT > 1 || ${#words[1]} > 0 || ${#current_word} > 0 ))
     then
       local curcontext=$( _zsh_autocomplete__context list-choices )


### PR DESCRIPTION
I was experiencing some odd flickering when using this plugin in Konsole as demonstrated in this video: https://asciinema.org/a/P7kiFIzUZSyByXqIT2JXPx9pI

I found that removing the specified line resolves this issue.