### PR TITLE
Scripts assume zsh location.

### DIFF
--- a/module/.autocomplete.__init__
+++ b/module/.autocomplete.__init__
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 zmodload -Fa zsh/files b:zf_mkdir b:zf_rm
 zmodload -Fa zsh/parameter p:functions
 zmodload -Fa zsh/zutil b:zstyle

--- a/module/.autocomplete.async
+++ b/module/.autocomplete.async
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 zmodload -Fa zsh/zpty b:zpty
 zmodload -Fa zsh/parameter p:funcstack p:functions p:parameters
 zmodload -Fa zsh/system p:sysparams

--- a/module/.autocomplete.compinit
+++ b/module/.autocomplete.compinit
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 zmodload -Fa zsh/files b:zf_rm
 zmodload -Fa zsh/parameter p:funcstack p:functions
 builtin autoload -Uz is-at-least

--- a/module/.autocomplete.config
+++ b/module/.autocomplete.config
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 zmodload -Fa zsh/zutil b:zstyle
 
 .autocomplete.config.precmd() {

--- a/module/.autocomplete.key
+++ b/module/.autocomplete.key
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 zmodload -Fa zsh/terminfo b:echoti p:terminfo
 builtin autoload -Uz add-zle-hook-widget
 

--- a/module/.autocomplete.key-binding
+++ b/module/.autocomplete.key-binding
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 zmodload zsh/complist
 zmodload -Fa zsh/parameter p:funcstack p:functions
 

--- a/module/.autocomplete.recent-dirs
+++ b/module/.autocomplete.recent-dirs
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 zmodload -Fa zsh/files b:zf_mv
 zmodload -Fa zsh/parameter p:commands p:dirstack p:functions
 

--- a/module/.autocomplete.widget
+++ b/module/.autocomplete.widget
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 typeset -g ZSH_AUTOSUGGEST_MANUAL_REBIND=1
 zmodload zsh/complist
 

--- a/run-tests.zsh
+++ b/run-tests.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh -f
+#!/usr/bin/env zsh -f
 print $ZSH_PATCHLEVEL
 local +h -a fpath=( ${0:h}/*(-/) $fpath )
 FPATH=$FPATH zsh -f =clitest --list-run --progress dot --prompt '%' -- ${0:h}/.clitest/*.md

--- a/utility/.autocomplete.patch
+++ b/utility/.autocomplete.patch
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 zmodload -Fa zsh/parameter p:functions
 
 .autocomplete.patch() {

--- a/utility/.autocomplete.zle-flags
+++ b/utility/.autocomplete.zle-flags
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 emulate -L zsh; setopt $_autocomplete__options
 
 # If no arg, assume same widget as last time.

--- a/widget/.autocomplete.complete-word.completion-widget
+++ b/widget/.autocomplete.complete-word.completion-widget
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 builtin autoload -Uz .autocomplete.complete-word.post
 
 local +h curcontext=${curcontext:-${WIDGET}:::}

--- a/widget/.autocomplete.down-line-or-select.zle-widget
+++ b/widget/.autocomplete.down-line-or-select.zle-widget
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 if [[ $RBUFFER == *$'\n'* ]]; then
   zle .down-line

--- a/widget/.autocomplete.history-search.completion-widget
+++ b/widget/.autocomplete.history-search.completion-widget
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 local 0=${(%):-%N}
 
 $0() {

--- a/widget/.autocomplete.history-search.zle-widget
+++ b/widget/.autocomplete.history-search.zle-widget
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 local 0=${(%):-%N}
 
 ${0}.context() {

--- a/widget/.autocomplete.list-expand.completion-widget
+++ b/widget/.autocomplete.list-expand.completion-widget
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 local 0=${(%):-%N}
 
 $0() {

--- a/widget/.autocomplete.up-line-or-search.zle-widget
+++ b/widget/.autocomplete.up-line-or-search.zle-widget
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 if [[ $LBUFFER == *$'\n'* ]]; then
   zle .up-line

--- a/zsh-autocomplete.plugin.zsh
+++ b/zsh-autocomplete.plugin.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 setopt NO_singlelinezle
 () {
   emulate -L zsh -o NO_aliases


### PR DESCRIPTION
We don't all install zsh to /bin.  It is part of the POSIX standard, however, to always have /usr/bin/env; thus I changed all "#!/bin/zsh" to "!#/usr/bin/env zsh".  Good?