### PR TITLE
Check for existence of $ZSH_COMPDUMP file (#433)

### DIFF
--- a/scripts/.autocomplete.compinit
+++ b/scripts/.autocomplete.compinit
@@ -26,7 +26,7 @@ compdef() {
 
   # Decrease Oh My Zsh start-up time. See below.
   local -Pa omzdump=()
-  [[ -v ZSH_COMPDUMP ]] &&
+  [[ -v ZSH_COMPDUMP && -f ZSH_COMPDUMP ]] &&
     omzdump=( ${(f)"$( < $ZSH_COMPDUMP )"} )
 
   typeset -gU FPATH fpath=( ~zsh-autocomplete/functions/completion $fpath[@] )


### PR DESCRIPTION
On occasion you can have $ZSH_COMPDUMP variable set but the file itself may not exist. This ensures the file is checkedd for.

Resolves: #433

