### PR TITLE
Add a section for usage with Oh My Zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,27 @@ Finally, restart your shell.
 To install with another Zsh framework or plugin manager, please refer to your
 framework's/plugin manager's documentation for instructions.
 
+#### Oh My Zsh
+The following command will clone the repo into the plugins directory of Oh My Zsh
+```zsh
+% git clone https://github.com/marlonrichert/zsh-autocomplete ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autocomplete
+```
+
+Then add the following to your `.zshrc` file:
+```
+plugins=(
+  ...
+  zsh-autosuggestions
+)
+```
+
+Lastly run the following commands to update your shell:
+```zsh
+% cd
+% source ~/.zshrc
+```
+
+
 ## Troubleshooting
 Try the steps in the [bug report template](.github/ISSUE_TEMPLATE/bug-report.md).
 


### PR DESCRIPTION
As Oh My Zsh might as well be the most popular framework for managing zsh configs I thought an own section might be helpful. I tried the the plugin ```zsh-autocomplete``` which comes directly with Oh My Zsh but like yours one way more. It took me a bit as someone not yet that proficient with working in the shell to install and make it work and think the short sub-section might be helpful for folks like me.

(Disclosure: This is my first pull request so please excuse me if I did not follow the conventions for Pull Requests correctly)
