### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,14 @@ To uninstall, simply undo the installation steps above in reverse order:
  1. Delete the repo you created in step 1.
 Finally, restart your shell.
 
+### Fig
+
+[Fig](https://fig.io) adds apps, shortcuts, and autocomplete to your existing terminal.
+
+Install `zsh-autocomplete` in just one click.
+
+<a href="https://fig.io/plugins/other/zsh-autocomplete" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
 ### Other Frameworks/Plugin Managers
 To install with another Zsh framework or plugin manager, please refer to your
 framework's/plugin manager's documentation for instructions.


### PR DESCRIPTION
Before submitting your pull request, please check the following:
* [x] There have _not_ been any other pull requests similar to yours.
* [x] Each of your commit messages follows the [Seven Rules of a Great Commit Message](https://cbea.ms/git-commit/#seven-rules).
* [x] You have [squashed](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing) any redundant or insignificant commits.

The [Fig Plugin Store](https://fig.io/plugins) supports 1-click install for 400+ shell plugins. We have over 100k users, thousands of whom manage their shell configuration with Fig.

Zsh Autocomplete is one of the most popular plugins on our store (on our front page, in fact), so we'd love to have it listed as a download method on your readme.

Thanks so much and please let me know if you have any questions!

