### PR TITLE
Fix recent-dirs naming conflict

### DIFF
--- a/scripts/.autocomplete.__init__
+++ b/scripts/.autocomplete.__init__
@@ -104,7 +104,7 @@ local -P zsh_cache_dir=${XDG_CACHE_HOME:-$HOME/.cache}/zsh
 
 local -P mod=
 for mod in compinit config widget key-binding recent-dirs async; do
-  if builtin zstyle -T ':autocomplete:' $mod; then
+  if builtin zstyle -T ":autocomplete:$mod" enabled; then
     builtin autoload +X -Uz ~zsh-autocomplete/scripts/.autocomplete.$mod
     {
       .autocomplete.$mod "$@"

--- a/scripts/.autocomplete.recent-dirs
+++ b/scripts/.autocomplete.recent-dirs
@@ -6,43 +6,43 @@ zmodload -F zsh/parameter p:commands p:dirstack p:functions
   # NOTE: Cannot set localopts, because of `cdr`, below.
 
   if [[ -v precmd_functions && $precmd_functions[(I)_zshz_precmd] != 0 ]] &&
-      builtin zstyle -T ':autocomplete:' recent-dirs 'zsh-z'; then
+      builtin zstyle -T ':autocomplete:recent-dirs' backend 'zsh-z'; then
     _autocomplete.recent_directories() {
       reply=( ${(f)"$( zshz --complete -l $1 2> /dev/null )"} )
     }
 
   elif [[ -v chpwd_functions && $chpwd_functions[(I)__zoxide_hook] != 0 ]] &&
-      builtin zstyle -T ':autocomplete:' recent-dirs 'zoxide'; then
+      builtin zstyle -T ':autocomplete:recent-dirs' backend'zoxide'; then
     _autocomplete.recent_directories() {
       reply=( ${(f)"$( zoxide query --list $1 2> /dev/null )"} )
     }
 
   elif [[ -v chpwd_functions && $chpwd_functions[(I)_zlua_precmd] != 0 ]] &&
-      builtin zstyle -T ':autocomplete:' recent-dirs 'z.lua'; then
+      builtin zstyle -T ':autocomplete:recent-dirs' backend 'z.lua'; then
     _autocomplete.recent_directories() {
       reply=( ${${(f)"$( _zlua --complete $1 2> /dev/null )"}##<->[[:space:]]##} )
     }
 
   elif [[ -v precmd_functions && $precmd_functions[(I)_z_precmd] != 0 ]] &&
-      builtin zstyle -T ':autocomplete:' recent-dirs 'z.sh'; then
+      builtin zstyle -T ':autocomplete:recent-dirs' backend 'z.sh'; then
     _autocomplete.recent_directories() {
       reply=( ${${(fOa)"$( _z -l $1 2>&1 )"}##(common:|<->)[[:space:]]##} )
     }
 
   elif [[ -v chpwd_functions && $chpwd_functions[(I)autojump_chpwd] != 0 ]] &&
-      builtin zstyle -T ':autocomplete:' recent-dirs 'autojump'; then
+      builtin zstyle -T ':autocomplete:recent-dirs' backend 'autojump'; then
     _autocomplete.recent_directories() {
       reply=( ${${(f)"$( autojump --complete $1 2> /dev/null )"}##${1}__<->__} )
     }
 
   elif [[ -v preexec_functions && $preexec_functions[(I)_fasd_preexec] != 0 ]] &&
-      builtin zstyle -T ':autocomplete:' recent-dirs 'fasd'; then
+      builtin zstyle -T ':autocomplete:recent-dirs' backend 'fasd'; then
     _autocomplete.recent_directories() {
       reply=( ${(f)"$( fasd -dlR $1 2> /dev/null )"} )
     }
 
   elif builtin autoload -RUz chpwd_recent_filehandler &&
-      builtin zstyle -T ':autocomplete:' recent-dirs 'cdr'; then
+      builtin zstyle -T ':autocomplete:recent-dirs' backend 'cdr'; then
     setopt autopushd pushdignoredups
 
     if ! builtin zstyle -s :chpwd: recent-dirs-file _; then


### PR DESCRIPTION
## Motivation
Setting the recent-dirs option `zstyle ':autocomplete:*' recent-dirs cdr` (to any value) in `.zshrc` causes this check to fail:
 https://github.com/marlonrichert/zsh-autocomplete/blob/4c363ff553be227db90842d7481fd6e02de8703c/scripts/.autocomplete.__init__#L106-L108
thereby preventing `scripts/.autocomplete.recent-dirs` from loading.

zsh version: zsh 5.8.1 (x86_64-apple-darwin21.0)

## Changes
Here I propose to resolve this conflict by either renaming the `recent-dirs` setting to `recent-dirs-function` or renaming the `.autocomplete.recent-dirs` script to `.autocomplete.recent-directories`.

__Points in favor of renaming the setting:__
- `recent-dirs-function` more closely describes the value being set.
- git doesn't always track revisions properly through a `git mv`.

__Points in favor of renaming the script:__
- No changes to rc files needed if `recent-dirs` is set. (Though the setting breaks recent directories anyway, so I'm not sure it is being used.)

I can see the merit in either option. What do you think?

##
Before submitting your pull request, please check the following:
* [x] There have _not_ been any other pull requests similar to yours.
* [x] Each of your commit messages follows the [Seven Rules of a Great Commit Message](https://cbea.ms/git-commit/#seven-rules).
* [x] You have [squashed](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing) any redundant or insignificant commits.
