### PR TITLE
Delete breaking zstyle from OMZ

### DIFF
--- a/scripts/.autocomplete.config
+++ b/scripts/.autocomplete.config
@@ -8,13 +8,11 @@ typeset -g ZLE_SPACE_SUFFIX_CHARS=$'|&<>-+'
   typeset -gH _comp_setup="$_comp_setup"';
       [[ $_comp_caller_options[globdots] == yes ]] && setopt globdots'
 
-  # Remove incompatible setting.
+  # Remove incompatible settings.
+  builtin zstyle -d ':completion:*:*:*:*:*' menu
   builtin zstyle -d ':completion:*:default' list-prompt
   unset LISTPROMPT
 }
-
-# Override incompatible setting.
-builtin zstyle ':completion:*:*:*:*:default' menu ''
 
 builtin zstyle ':completion:*' use-cache yes
 builtin zstyle -e ':completion:*' cache-path _autocomplete.config.cache-path


### PR DESCRIPTION
Reverts part of 96bbb5bb5b3698ca23d54ee28eb595a3727bf6df. Fixes #483.