### PR TITLE
Add optional vi-like arrow keys to .zshrc

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -97,3 +97,9 @@ bindkey '\0' list-expand
 bindkey -M menuselect '\r' .accept-line
 # .accept-line: Accept command line.
 # accept-line:  Accept selection and exit menu.
+
+# Uncomment the following lines to add vi-like arrow keys in completion menu & history menu:
+# bindkey -M menuselect '^H' backward-char
+# bindkey -M menuselect '^J' down-line-or-history
+# bindkey -M menuselect '^K' up-line-or-history
+# bindkey -M menuselect '^L' forward-char


### PR DESCRIPTION
## Motivation
The fzf menu uses vi-style arrow keys to move its cursor (Ctrl-J down, Ctrl-K up, https://github.com/junegunn/fzf#using-the-finder ). For consistency I have set my zsh-autocomplete menu to behave the same.

## Changes
This PR adds those keys to `.zshrc` as an optional suggestion in case others would find that useful.

## Setting arrow keys by default?
I wonder if it makes sense to enable vi arrow keys by default, like fzf, to allow navigation of the completions without leaving the homerow. 

These are the default global bindings for those keys:

- `^H` is unbound
- `^J` is accept-line
- `^K` is kill-line
- `^L` is clear-screen

Overall, these don't seem critical to have enabled *specifically* within the completions menu, with some possible exceptions.
- The `^J` would get in the way for some, though I'm not sure how many use `^J` instead of the Enter key or have a terminal that sends `^J` instead of `^M` for Enter.
- Perhaps clear-screen would make space for more completions while keeping the menu open, but the list-lines setting should already take care of that. 

 It probably still makes sense to keep as an option, but I'm curious to hear your thoughts.