### PR TITLE
fix(#540): address typo that breaks autocomplete

### DIFF
--- a/scripts/.autocomplete.compinit
+++ b/scripts/.autocomplete.compinit
@@ -113,7 +113,7 @@ EOF
         functions[compadd]=$functions[.autocomplete.compadd]
 
     local +h -a comppostfuncs=( autocomplete:new:_main_complete.post "$comppostfuncs[@]" )
-    :autocomplete:old:_main_complete "$@"
+    autocomplete:old:_main_complete "$@"
   }
 
   # Add support for coloring file types to _expand.


### PR DESCRIPTION
Fixes #540 Commit 8ef6b7373139980412b3100c274dd14384901dcd has a typo that broke autocomplete.