### PR TITLE
Fix empty strings are not checked whether match ignored-input

### DIFF
--- a/scripts/.autocomplete.async
+++ b/scripts/.autocomplete.async
@@ -400,7 +400,7 @@ log_functions+=( .autocomplete.async.complete.fd-widget.inner )
   builtin zstyle -s ":autocomplete:${curcontext}:" ignored-input ignored
 
   if (( ${#words[@]} == 1 && ${#words[CURRENT]} < min_input )) ||
-      [[ -n $words[CURRENT] && $words[CURRENT] == $~ignored ]]; then
+      [[ -n $ignored && $words[CURRENT] == $~ignored ]]; then
     compstate[list]=
     false
   else


### PR DESCRIPTION
Thanks for your awesome plugin!

I was trying to make the autocomplete to show when I typed at least one character of cli arguments (`ignored-input='^?##'`), but I found that empty strings will always trigger the autocomplete. So I made a commit that fixes this issue.