### PR TITLE
Remove suffix from BUFFER instead of LBUFFER

### DIFF
--- a/Completions/_autocomplete__history_lines
+++ b/Completions/_autocomplete__history_lines
@@ -148,7 +148,7 @@ _autocomplete__history_lines() {
 
 _autocomplete__history_lines_suffix() {
   [[ $KEYS[-1] != $'\C-@' ]] &&
-      LBUFFER=$LBUFFER[1,-1-$1]
+      BUFFER=$BUFFER[1,-1-$1]
 }
 
 _autocomplete__history_lines "$@"


### PR DESCRIPTION
Fixes #667.

Before submitting your PR (pull request), please
check the following:
* [x] There is no other PR (open or closed) similar to yours. If there is, please first discuss over there.
* [x] Each commit messages follows the [Seven Rules of a Great Commit Message](https://cbea.ms/git-commit/#seven-rules).
* [x] Each commit message includes `Fixes #<bug>` or `Resolves #<issue>` in its body (not subject) for each issue it resolves (if any).
* [x] You have [squashed](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing) any redundant or insignificant commits.


I don't see any downside to remove from `BUFFER` instead of `LBUFFER`, it works wells outside vi-mode too. If you see any problem with this approach let me know and we can hopefully find a better solution.

Best