### PR TITLE
Complete recent files with globbed-files comp tag

### DIFF
--- a/Completions/_autocomplete__recent_paths
+++ b/Completions/_autocomplete__recent_paths
@@ -13,10 +13,10 @@ _autocomplete__recent_paths() {
   local -P tag=
   for tag in directories files; do
     if [[ -v functions[+autocomplete:recent-$tag] &&
-            $_comp_tags == (|* )(|(all|local)-)$tag(| *) ]] &&
+            $_comp_tags == (|* )(|(all|local|globbed)-)$tag(| *) ]] &&
         +autocomplete:recent-$tag "$PREFIX$SUFFIX"; then
       files=( "$reply[@]" )
-      _description -V recent-$tag expl 'recent directory'
+      _description -V recent-$tag expl "recent $tag"
       _autocomplete__recent_paths_add $files[@] &&
           ret=0
     fi


### PR DESCRIPTION
- Complete recent files (if defined) if comp tag contains globbed-files
- Set proper description for the completion (atm both are called recent directory which is wrong)

Before:
![image](https://github.com/marlonrichert/zsh-autocomplete/assets/5115805/49c53248-37ee-4175-bc39-ab1472413aea)

After:
![image](https://github.com/marlonrichert/zsh-autocomplete/assets/5115805/78d5699e-9eb5-4b40-84d8-dbefe191130f)

