### PR TITLE
readme: add min-input config

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,12 @@ This will make Autocomplete behave as if you pressed <kbd>Ctrl</kbd><kbd>R</kbd>
 zstyle ':autocomplete:*' default-context history-incremental-search-backward
 ```
 
+### Wait for a minimum amount of input
+To suppress autocompletion until a minimum number of characters have been typed:
+```zsh
+zstyle ':autocomplete:*' min-input 3
+```
+
 ### Wait with autocompletion until typing stops for a certain amount of seconds
 Normally, Autocomplete fetches completions after you stop typing for about 0.05 seconds. You can change this as follows:
 ```zsh


### PR DESCRIPTION
I was looking for a way to suppress autocomplete until a certain number of characters was input -- and found this resolved issue (https://github.com/marlonrichert/zsh-autocomplete/issues/47). 
However, the link and config is no longer in the README. 

I dug through the git history to find the config and it worked for me -- so I think we can add this back to the README?