### PR TITLE
Fix ignored widget pattern matching expansion

### DIFF
--- a/Functions/Init/.autocomplete__async
+++ b/Functions/Init/.autocomplete__async
@@ -123,7 +123,7 @@ ${0}:precmd() {
       'what-cursor-position'
       'where-is'
     )
-    [[ ${LASTWIDGET##.} == (${(~j:|:)ignored}) ]] &&
+    [[ ${LASTWIDGET##.} == (${(~j:|:)~ignored}) ]] &&
         return 0
 
     [[ $KEYS == ([\ -+*]|$'\e\t') ]] &&


### PR DESCRIPTION
The `GLOB_SUBST` option (${~...}) needs to be set to interpret the expansion result as a pattern.
