### PR TITLE
Add an option to autocomplete history in a single fashion.

### DIFF
--- a/Completions/_autocomplete__history_lines
+++ b/Completions/_autocomplete__history_lines
@@ -134,8 +134,10 @@ _autocomplete__history_lines() {
 
   local -Pa suf=( -S '' )
   if [[ $WIDGETSTYLE == *-select* && $#matches[@] > 1 ]]; then
-    # Enable multi-select.
-    suf=( -S ';' -R _autocomplete__history_lines_suffix )
+    # By default, enable multi-select.
+    if ! zstyle -t ":autocomplete:${curcontext}:" single-history; then
+      suf=( -S ';' -R _autocomplete__history_lines_suffix )
+    fi
   fi
 
   local tag=history-lines


### PR DESCRIPTION
By default zsh-autocomplete will continue to add a semicolon and continue history lookups, but if you put this in your config, it'll switch to single mode:

zstyle ':completion:*:history-lines:*' single-history yes

@marlonrichert  - If there's something similar already there or you don't like it, I'm open to suggestions.  Thanks.