### PR TITLE
Add zsh version switch for suffix removal feature

### DIFF
--- a/Completions/_autocomplete__history_lines
+++ b/Completions/_autocomplete__history_lines
@@ -146,11 +146,17 @@ _autocomplete__history_lines() {
   builtin compadd "$suf[@]" -QU -ld displays "$expl[@]" -a matches
 }
 
-_autocomplete__history_lines_suffix() {
-  if [[ SUFFIX_ACTIVE -ne 0 && $WIDGET != history-search-backward ]]; then
-    LBUFFER="$LBUFFER[1,SUFFIX_START]"
-    RBUFFER="$RBUFFER[SUFFIX_END,-1]"
-  fi
-}
+if is-at-least 5.9; then
+  _autocomplete__history_lines_suffix() {
+    if [[ SUFFIX_ACTIVE -ne 0 && $WIDGET != history-search-backward ]]; then
+      LBUFFER="$LBUFFER[1,SUFFIX_START]"
+      RBUFFER="$RBUFFER[SUFFIX_END,-1]"
+    fi
+  }
+else
+  _autocomplete__history_lines_suffix() {
+    [[ $KEYS[-1] != $'\C-@' ]] && LBUFFER=$LBUFFER[1,-1-$1]
+  }
+fi
 
 _autocomplete__history_lines "$@"


### PR DESCRIPTION
Fixes #797 on older machines by reverting to pre 11f1145 code for old zsh versions.

Before submitting your Pull Request (PR), please check the following:
* [x] There is no other PR (open or closed) similar to yours. If there is, please first discuss over there.
* [x] Your new code in each file follows the same style as the existing code in that file.
* [x] Each commit messages follows the [Seven Rules of a Great Commit Message](https://cbea.ms/git-commit/#seven-rules).
* [x] Each commit message includes `Fixes #<bug>` or `Resolves #<issue>` in its body (not subject, that is, the first line) for each issue it resolves (if any).
* [x] You have [squashed](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing) any redundant or insignificant commits.

I did not look into where the actual incompatibility came from and just tried to

1. revert only the condition,
2. revert only the buffer change
3. revert the whole function

on a 22.04 Ubuntu with zsh 5.8.1.
Only the last option worked, so this is what I suggest.