### PR TITLE
Add option for appending semicolons

### DIFF
--- a/Completions/_autocomplete__history_lines
+++ b/Completions/_autocomplete__history_lines
@@ -133,10 +133,9 @@ _autocomplete__history_lines() {
   fi
 
   local -Pa suf=( -S '' )
-  if [[ $WIDGETSTYLE == *-select* && $#matches[@] > 1 ]]; then
-    # Enable multi-select.
+  zstyle -t ":autocomplete:$curcontext" append-semicolon; [[ $? != 1 ]] &&
+    [[ $WIDGETSTYLE == *-select* && $#matches[@] > 1 ]] &&
     suf=( -S ';' -R _autocomplete__history_lines_suffix )
-  fi
 
   local tag=history-lines
   _comp_tags=" $tag"

--- a/README.md
+++ b/README.md
@@ -339,6 +339,14 @@ a backend for it:
 }
 ```
 
+## Disable automatically added semicolons
+Autocomplete adds a semicolon to each line to allow selecting another line afterwards.
+The added semicolon get removed on most keystrokes besides <kbd>↑</kbd>.
+You can deactivate this feature by setting `append-semicolon` to a non-true value:
+```zsh
+zstyle ':autocomplete:*' append-semicolon off
+```
+
 ## Troubleshooting
 Try the steps in the
 [bug report template](.github/ISSUE_TEMPLATE/bug-report.md).


### PR DESCRIPTION
Before submitting your Pull Request (PR), please check the following:
* [x] There is no other PR (open or closed) similar to yours. If there is, please first discuss over there.
* [x] Your new code in each file follows the same style as the existing code in that file.
* [x] Each commit messages follows the [Seven Rules of a Great Commit Message](https://cbea.ms/git-commit/#seven-rules).
* [x] Each commit message includes `Fixes #<bug>` or `Resolves #<issue>` in its body (not subject, that is, the first line) for each issue it resolves (if any).
* [x] You have [squashed](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing) any redundant or insignificant commits.

This was asked for in [an old comment](https://github.com/marlonrichert/zsh-autocomplete/issues/361#issuecomment-970833500). My use case was to have a line
```zsh
is-at-least 5.9 || zstyle ':autocomplete:*' append-semicolon off
```
as a quick fix for #797 on old machines, before I wrote #818.

I do assume, this option comes with the risk, that the next time some semicolon suffix struggle arises, people just deactivate this feature and then do not notice, when you fix it. So, merge at your own discretion.