### PR TITLE
[ Merged as a3e4b59 ] Update package name to reflect AUR package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ First, install Autocomplete itself. Here are some way to do so:
     manager. As of this writing, this package is available through Homebrew, Nix, `pacman`, Plumage,
     and (as `app-shells/zsh-autocomplete`) Portage.
   * To always use the latest commit on the `main` branch, do one of the following:
-    * Use `pacman` to install `zsh-autocomplete-git`.
+    * Use `pacman` to install `zsh-autocomplete`.
     * Use a Zsh plugin manager to install `marlonrichert/zsh-autocomplete`. (If you don't have a
       plugin manager yet, I recommend using [Znap](https://github.com/marlonrichert/zsh-snap).)
     * Clone the repo directly:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ First, install Autocomplete itself. Here are some way to do so:
     manager. As of this writing, this package is available through Homebrew, Nix, `pacman`, Plumage,
     and (as `app-shells/zsh-autocomplete`) Portage.
   * To always use the latest commit on the `main` branch, do one of the following:
-    * Use `pacman` to install `zsh-autocomplete`.
+    * Install the AUR package [zsh-autocomplete-git](https://aur.archlinux.org/packages/zsh-autocomplete-git)<sup>AUR</sup> from the Arch User Repository (for example, using [yay](https://github.com/Jguer/yay), an AUR helper):
+      ```sh
+       yay -S zsh-autocomplete-git
+      ```
     * Use a Zsh plugin manager to install `marlonrichert/zsh-autocomplete`. (If you don't have a
       plugin manager yet, I recommend using [Znap](https://github.com/marlonrichert/zsh-snap).)
     * Clone the repo directly:


### PR DESCRIPTION
The package `zsh-autocomplete-git` has been renamed to `zsh-autocomplete` in the official Arch repository.

Before submitting your Pull Request (PR), please check the following:
* [x] There is no other PR (open or closed) similar to yours. If there is, please first discuss over there.
* [x] Your new code in each file follows the same style as the existing code in that file.
* [x] Each commit messages follows the [Seven Rules of a Great Commit Message](https://cbea.ms/git-commit/#seven-rules).
* [x] Each commit message includes `Fixes #<bug>` or `Resolves #<issue>` in its body (not subject, that is, the
  first line) for each issue it resolves (if any).
* [x] You have [squashed](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing) any redundant or insignificant commits.

I was a bit confused when I ran `pacman -S zsh-autocomplete-git`, but after checking the Arch official repository, it seems the `-git` suffix has been removed.

Package: [zsh-autocomplete](https://archlinux.org/packages/extra/any/zsh-autocomplete/)