### PR TITLE
Minor README correction for add-semicolon zstyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ then a space is never inserted.
 By default, Autocomplete adds a semicolon to each history line to allow adding another line with
 <kbd>Ctrl</kbd><kbd>Space</kbd>. You can deactivate this feature as follows:
 ```zsh
-zstyle ':autocomplete:*' append-semicolon no
+zstyle ':autocomplete:*' add-semicolon no
 ```
 
 ### Start each command line in history search mode


### PR DESCRIPTION
Commit 6f6f9cc helpfully added the ability to turn off semicolon addition when using history but the README has a typo.  Teeny coimmit here to correct that typo