### PR TITLE
Prevent exec from permanently redirecting stderr

### DIFF
--- a/Functions/Init/.autocomplete__async
+++ b/Functions/Init/.autocomplete__async
@@ -210,7 +210,7 @@ ${0}:precmd() {
   if [[ -v _autocomplete__async_fd && _autocomplete__async_fd -ge 10 ]]; then
     # Unhook and close the previous fd. (If it no longer exists, then this will fail harmlessly.)
     builtin zle -F "$_autocomplete__async_fd" 2>/dev/null
-    exec {_autocomplete__async_fd}<&- 2>/dev/null
+    { exec {_autocomplete__async_fd}<&- } 2>/dev/null
   fi
 
   typeset -g _autocomplete__async_fd=
@@ -347,7 +347,7 @@ ${0}:precmd() {
   {
     local +h -F SECONDS=0.0
     {
-      builtin zle -F $fd # Unhook ourselves immediately, so we don't get called more than once.
+      builtin zle -F $fd 2>/dev/null # Unhook ourselves immediately, so we don't get called more than once.
 
       if [[ -n $_autocomplete__zle_flags ]]; then
         builtin zle -f $_autocomplete__zle_flags
@@ -368,7 +368,7 @@ ${0}:precmd() {
       (( SECONDS += reply[2] ))
 
     } always {
-      exec {fd}<&-
+      { exec {fd}<&- } 2>/dev/null
       [[ -v _autocomplete__async_fd && $_autocomplete__async_fd == $fd ]] &&
           unset _autocomplete__async_fd
     }


### PR DESCRIPTION
Commit 2be4e7f introduced a cleanup mechanism in `.autocomplete:async:start()` to unhook and close the previous fd before starting a new async operation. However, the line:

```zsh
exec {_autocomplete__async_fd}<&- 2>/dev/null
```

permanently redirects stderr to /dev/null for the current shell, because exec without a command applies all accompanying redirections to the current shell. While the intent was
only to suppress errors from closing a stale fd, it also silenced stderr for the entire session.

Additionally, because `start()` now proactively cleans up the previous fd, the `complete:fd-widget` callback can fire after the fd has already been unhooked and closed, producing
harmless but noisy errors:

```txt
No handler installed for fd N
failed to close file descriptor N: bad file descriptor
```

These were hidden by the same exec ... `2>/dev/null` bug.

Fix

- Wrap exec `{fd}<&- calls` in command groups { } so that `2>/dev/null` only applies within the group and stderr is restored afterward
- Suppress the expected race condition errors in `complete:fd-widget` individually


Fix #848

Before submitting your Pull Request (PR), please check the following:
* [x] There is no other PR (open or closed) similar to yours. If there is, please first discuss over there.
* [x] Your new code in each file follows the same style as the existing code in that file.
* [x] Each commit messages follows the [Seven Rules of a Great Commit Message](https://cbea.ms/git-commit/#seven-rules).
* [x] Each commit message includes `Fixes #<bug>` or `Resolves #<issue>` in its body (not subject, that is, the
  first line) for each issue it resolves (if any).
* [x] You have [squashed](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing) any redundant or insignificant commits.
