### PR TITLE
Fix file descriptor leaks in async workers

### DIFF
--- a/Functions/Init/.autocomplete__async
+++ b/Functions/Init/.autocomplete__async
@@ -152,8 +152,9 @@ ${0}:precmd() {
 .autocomplete:async:clear() {
   # If we exit the ZLE before the last hook widget called, then it won't be able to close the fd.
   [[
-    -v _autocomplete__async_fd && _autocomplete__async_fd -ge 10 && -t $_autocomplete__async_fd
+    -v _autocomplete_async_fd && _autocomplete_async_fd -ge 10
   ]] &&
+    { : <&$_autocomplete_async_fd } 2>/dev/null &&
     exec {_autocomplete_async_fd}<&- &&
     unset _autocomplete_async_fd
   unset curcontext _autocomplete__isearch
@@ -194,7 +195,7 @@ ${0}:precmd() {
 
   # Unhook ourselves immediately, so we don't get called more than once.
   builtin zle -F "$fd" 2> /dev/null
-  [[ -t $fd ]] && exec {fd}<&-
+  { : <&$fd } 2>/dev/null && exec {fd}<&-
 
   if [[ -n $_autocomplete__zle_flags ]]; then
     builtin zle -f $_autocomplete__zle_flags
@@ -370,7 +371,7 @@ ${0}:precmd() {
       (( SECONDS += reply[2] ))
 
     } always {
-      [[ -t $fd ]] && exec {fd}<&-
+      { : <&$fd } 2>/dev/null && exec {fd}<&-
     }
 
     [[ -n $curcontext ]] &&


### PR DESCRIPTION
*Note: The description for this PR was drafted with the help of Gemini 3.1 Pro.*

Before submitting your Pull Request (PR), please check the following:
* [x] There is no other PR (open or closed) similar to yours. If there is, please first discuss over there.
* [x] Your new code in each file follows the same style as the existing code in that file.
* [x] Each commit messages follows the [Seven Rules of a Great Commit Message](https://cbea.ms/git-commit/#seven-rules).
* [x] Each commit message includes `Fixes #<bug>` or `Resolves #<issue>` in its body (not subject, that is, the first line) for each issue it resolves (if any).
* [x] You have [squashed](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing) any redundant or insignificant commits.

**The Problem**
After extended use of the terminal, users experience recurring crashes with the following error messages, eventually completely breaking autocompletion:
```text
.autocomplete:async:wait:sysopen:2: can't open file /dev/fd/-1: no such file or directory
.autocomplete:async:wait:17: write error: bad file descriptor
```
This occurs because the plugin leaks file descriptors on every keystroke. Once the OS open-file limit is reached (commonly 256), Zsh fails to allocate new pipes for process substitution `<(...)`. 

**Root Causes**
Upon investigating `Functions/Init/.autocomplete__async`, two bugs prevent FDs from closing:
1. **Typo in `.autocomplete:async:clear`:** The `if` condition checks for `_autocomplete__async_fd` (double underscore), while the actual file descriptor is stored in `_autocomplete_async_fd` (single underscore). The cleanup block is bypassed entirely when exiting ZLE.
2. **Flawed FD check (`[[ -t $fd ]]`):** In multiple functions, the code uses `[[ -t $fd ]]` before closing the descriptor via `exec {fd}<&-`. The `-t` flag checks if an FD is connected to a *terminal (TTY)*. Because the async workers use pipes, they are never connected to a terminal, so this evaluates to `false` 100% of the time, leaking the FD.

**Proposed Changes**
* **`Functions/Init/.autocomplete__async`**:
  * Fixed the variable name typo in `.autocomplete:async:clear`.
  * Removed the `[[ -t $fd ]]` checks in `.autocomplete:async:clear`, `.autocomplete:async:wait:fd-widget`, and `.autocomplete:async:complete:fd-widget`.
  * Replaced them with `{ : <&$fd } 2>/dev/null && exec {fd}<&-`. This safely peeks to see if the file descriptor is open before closing it. Importantly, it avoids using a bare `exec 2>/dev/null`, which would unintentionally redirect the global shell `stderr` and break the output of background commands like `git clone`.
