### PR TITLE
Fix variable name mismatch in async clear causing fd leak

### DIFF
--- a/Functions/Init/.autocomplete__async
+++ b/Functions/Init/.autocomplete__async
@@ -152,7 +152,7 @@ ${0}:precmd() {
 .autocomplete:async:clear() {
   # If we exit the ZLE before the last hook widget called, then it won't be able to close the fd.
   [[
-    -v _autocomplete__async_fd && _autocomplete__async_fd -ge 10 && -t $_autocomplete__async_fd
+    -v _autocomplete_async_fd && _autocomplete_async_fd -ge 10 && -t $_autocomplete_async_fd
   ]] &&
     exec {_autocomplete_async_fd}<&- &&
     unset _autocomplete_async_fd


### PR DESCRIPTION
## Summary

- `.autocomplete:async:clear()` checks `_autocomplete__async_fd` (double underscore) but the actual variable set by `wait()` and `start()` is `_autocomplete_async_fd` (single underscore)
- The cleanup condition never matches, so file descriptors are never closed when exiting ZLE early
- Over time the leaked fds exhaust the process limit

## Symptoms

```
_zsh_highlight:111: too many open files: /dev/null
.autocomplete:async:wait:sysopen:2: can't open file /dev/fd/-1: no such file or directory
.autocomplete:async:wait:17: write error: bad file descriptor
```

## Fix

One-character change: `_autocomplete__async_fd` → `_autocomplete_async_fd` in the `-v` test on line 155, matching the variable name used everywhere else in the file.