### PR TITLE
Fix multi-word history search

### DIFF
--- a/Completions/_autocomplete__history_lines
+++ b/Completions/_autocomplete__history_lines
@@ -10,7 +10,7 @@ _autocomplete__history_lines() {
   local -P lbuffer='' rbuffer=''
 
   (( CURRENT > 1 )) &&
-      lbuffer="${(j.[[:blank:]]##.)${(@b)words[1,CURRENT-1]}}[[:blank:]]##"
+      lbuffer="*${(j.[[:blank:]]##.)${(@b)words[1,CURRENT-1]}}[[:blank:]]##"
   (( CURRENT < $#words[@] )) &&
       rbuffer="[[:blank:]]##${(j.[[:blank:]]##.)${(@b)words[CURRENT+1,-1]}}"
   lbuffer="$lbuffer${(b)QIPREFIX}"


### PR DESCRIPTION
Fix #860 => Prepend wildcard to lbuffer when CURRENT > 1 so that multi-word history searches (e.g. 'install f') match history entries where the typed words appear mid-line (e.g. 'brew install fzf'), not only at the start (e.g., 'install foo').

Before submitting your Pull Request (PR), please check the following:
* [x] There is no other PR (open or closed) similar to yours. If there is, please first discuss over there.
* [x] Your new code in each file follows the same style as the existing code in that file.
* [x] Each commit messages follows the [Seven Rules of a Great Commit Message](https://cbea.ms/git-commit/#seven-rules).
* [x] Each commit message includes `Fixes #<bug>` or `Resolves #<issue>` in its body (not subject, that is, the
  first line) for each issue it resolves (if any).
* [x] You have [squashed](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing) any redundant or insignificant commits.