### PR TITLE
Fix async fd cleanup

### DIFF
--- a/Functions/Init/.autocomplete__async
+++ b/Functions/Init/.autocomplete__async
@@ -152,7 +152,7 @@ ${0}:precmd() {
 .autocomplete:async:clear() {
   # If we exit the ZLE before the last hook widget called, then it won't be able to close the fd.
   [[
-    -v _autocomplete__async_fd && _autocomplete__async_fd -ge 10 && -t $_autocomplete__async_fd
+    -v _autocomplete_async_fd && _autocomplete_async_fd -ge 10
   ]] &&
     exec {_autocomplete_async_fd}<&- &&
     unset _autocomplete_async_fd
@@ -194,7 +194,7 @@ ${0}:precmd() {
 
   # Unhook ourselves immediately, so we don't get called more than once.
   builtin zle -F "$fd" 2> /dev/null
-  [[ -t $fd ]] && exec {fd}<&-
+  (( fd >= 10 )) && exec {fd}<&-
 
   if [[ -n $_autocomplete__zle_flags ]]; then
     builtin zle -f $_autocomplete__zle_flags
@@ -370,7 +370,7 @@ ${0}:precmd() {
       (( SECONDS += reply[2] ))
 
     } always {
-      [[ -t $fd ]] && exec {fd}<&-
+      (( fd >= 10 )) && exec {fd}<&-
     }
 
     [[ -n $curcontext ]] &&


### PR DESCRIPTION
## Summary

- close async pipe fds regardless of `-t`, because these fds come from process substitution and are not ttys
- fix the `_autocomplete__async_fd` / `_autocomplete_async_fd` variable mismatch in `.autocomplete:async:clear()`
- keep the existing `fd >= 10` guard before closing callback fds

Fixes #862. Related to #853 and #857.

## Validation

- Local PTY smoke test: repeated prompts kept pipe fd count flat (`7,7,7,7,7`) instead of growing.
- `zsh -f ./run-tests.zsh` could not run in my local checkout because the `clitest` submodule/dependency is not initialized: `zsh: can't open input file: clitest/clitest`.

## Disclosure

This PR was written with Codex.


Note: requested disclosure wording: written with Cdex.
