### PR TITLE
Prevent brace expansion on quoted words

### DIFF
--- a/Functions/Init/.autocomplete__compinit
+++ b/Functions/Init/.autocomplete__compinit
@@ -134,6 +134,10 @@ EOF
     MENUSCROLL=0
   }
 
+  # Prevent brace expansion on quoted words
+  .autocomplete__patch _expand
+  functions[_expand]="${functions[autocomplete:_expand:old]/\[ignorebraces\] == on &&/[ignorebraces] == on && -z \$compstate[quote] &&}"
+
   .autocomplete__patch _complete
   _complete() {
     local -i nmatches=$compstate[nmatches]


### PR DESCRIPTION
## Problem
The plugin incorrectly displays completions with expanded braces that are inside single or double quotes.
For example, typing
```zsh
mkdir '{1,2} ()'
```
shows `1 ()` and `2 ()` as completion candidates.

## Fix
Patch `_expand` to not expand braces on quoted words by adding a `-z \$compstate[quote]` condition