### PR TITLE
feat: per-command toggle for real-time completion (closes #776)

### DIFF
--- a/Functions/Init/.autocomplete__async
+++ b/Functions/Init/.autocomplete__async
@@ -118,6 +118,11 @@ ${0}:precmd() {
     builtin zstyle -t ":autocomplete:${LASTWIDGET}:" ignore &&
         return 0
 
+    .autocomplete:async:command-disabled && {
+      builtin zle -Rc
+      return 0
+    }
+
     local -Pa ignored=(
       '_complete_help'
       '(copy|insert)-*-word'
@@ -147,6 +152,59 @@ ${0}:precmd() {
   }
 
   return 0
+}
+
+# Returns true if real-time autocompletion should be suppressed for the command
+# on the current line, based on the `enabled-commands` (whitelist) and
+# `disabled-commands` (blacklist) styles. Whitelist takes precedence: if it is
+# set, only its commands are completed. Returns false (do complete) when neither
+# style is set, so this is a no-op unless the user opts in.
+.autocomplete:async:command-disabled() {
+  setopt localoptions extendedglob
+
+  local -a enabled=() disabled=()
+  builtin zstyle -a ":autocomplete:${curcontext}:" enabled-commands enabled
+  builtin zstyle -a ":autocomplete:${curcontext}:" disabled-commands disabled
+
+  (( $#enabled || $#disabled )) ||
+      return 1
+
+  # Lex the command line the same way the shell would.
+  local -a words=( ${(z)BUFFER} )
+
+  # While still typing the first word (and no space follows it yet), we're
+  # completing the command name itself, so never suppress: that would break
+  # command-name completion, including for whitelisted commands.
+  (( $#words > 1 )) || [[ $BUFFER == *[[:space:]] ]] ||
+      return 1
+
+  # Find the command word, skipping variable assignments and precommand
+  # modifiers like `sudo` so that e.g. `sudo ls` matches `ls`.
+  local word= command=
+  local -a precommands=(
+    - builtin command doas env exec nocorrect noglob sudo time
+  )
+  for word in $words; do
+    [[ $word == [[:IDENT:]]##=* ]] && continue
+    (( ${precommands[(I)$word]} )) && continue
+    command=$word
+    break
+  done
+  [[ -n $command ]] ||
+      return 1
+
+  # Match against the command as typed and its base name (e.g. /bin/ls -> ls).
+  local -a names=( $command ${command:t} )
+
+  if (( $#enabled )); then
+    # Whitelist: suppress unless the command matches.
+    [[ -n ${names[(r)(${(~j:|:)~enabled})]} ]] &&
+        return 1
+    return 0
+  fi
+
+  # Blacklist: suppress if the command matches.
+  [[ -n ${names[(r)(${(~j:|:)~disabled})]} ]]
 }
 
 .autocomplete:async:clear() {

--- a/README.md
+++ b/README.md
@@ -297,6 +297,29 @@ more dots:
 zstyle ':autocomplete:*' ignored-input '..##'
 ```
 
+### Enable or disable autocompletion for specific commands
+By default, Autocomplete shows real-time completions for every command. You can limit this to a
+chosen set of commands (a whitelist) or exclude certain commands (a blacklist). This is useful to
+hide completions for commands where they aren't helpful (like `ls`), or to keep them only for
+commands where they are (like `git` or `curl`):
+
+```zsh
+# Blacklist: autocomplete everything EXCEPT these commands.
+zstyle ':autocomplete:*' disabled-commands 'ls' 'cd' 'pwd'
+
+# Whitelist: autocomplete ONLY these commands.
+zstyle ':autocomplete:*' enabled-commands 'git' 'curl' 'docker' 'kubectl'
+```
+
+Each value is a glob pattern, so you can match groups of commands, e.g. `'kube*'`. Matching is done
+against both the command as typed and its base name, so `/usr/bin/ls` matches `ls`, and leading
+variable assignments and precommand modifiers such as `sudo` are skipped (`sudo ls` matches `ls`).
+Completion for the command name itself is never suppressed, so you can always complete the command
+you're typing.
+
+If `enabled-commands` is set, it takes precedence and `disabled-commands` is ignored. Setting
+neither (the default) completes every command.
+
 ## Change the max number of lines shown
 By default, Autocomplete lets the history menu fill half of the screen, and limits all real-time
 listings to a maximum of 16 lines. You can change these limits as follows:


### PR DESCRIPTION
## What

Adds two `zstyle` options to selectively enable or disable real-time autocompletion per command, as requested in #776:

```zsh
# Blacklist: autocomplete everything EXCEPT these commands.
zstyle ':autocomplete:*' disabled-commands 'ls' 'cd' 'pwd'

# Whitelist: autocomplete ONLY these commands.
zstyle ':autocomplete:*' enabled-commands 'git' 'curl' 'docker' 'kubectl'
```

I used `zstyle` rather than the plain shell variables originally sketched in the issue, to stay consistent with every other configuration option in the plugin (`min-input`, `ignored-input`, etc.).

## Why

Per #776 (5 👍): users want to hide completions for commands where they aren't helpful (like `ls`), or keep them only where they are (like `git`/`curl`), and reduce overhead on slower systems.

## How

- New helper `.autocomplete:async:command-disabled`, wired into `.autocomplete:async:complete` (the `line-pre-redraw` hook) **before** the async completion machinery starts — so suppressed commands skip the work entirely, addressing the performance motivation.
- `enabled-commands` (whitelist) takes precedence over `disabled-commands` (blacklist).
- Setting neither is a complete no-op: every command completes, exactly as today.
- Values are glob patterns (e.g. `'kube*'`).
- Matches both the command as typed and its base name (`/usr/bin/ls` → `ls`).
- Skips leading `VAR=value` assignments and precommand modifiers, so `sudo ls` matches `ls`.
- Never suppresses completion of the command name currently being typed, so command-name completion always works — including in whitelist mode.

## Tests

- Existing suite: 51/51 pass.
- Manually exercised the matching logic across blacklist/whitelist, glob patterns, `sudo`, full paths, `VAR=` assignments, and command-name typing.

Closes #776