### PR TITLE
Fix async completion leaking a pipe fd every cycle

### DIFF
--- a/Functions/Init/.autocomplete__async
+++ b/Functions/Init/.autocomplete__async
@@ -151,10 +151,10 @@ ${0}:precmd() {
 
 .autocomplete:async:clear() {
   # If we exit the ZLE before the last hook widget called, then it won't be able to close the fd.
-  [[
-    -v _autocomplete__async_fd && _autocomplete__async_fd -ge 10 && -t $_autocomplete__async_fd
-  ]] &&
-    exec {_autocomplete_async_fd}<&- &&
+  # The fd is a pipe from `sysopen <(...)`, so close it unconditionally: a `-t` (tty) guard is always
+  # false here, and the previous guard also tested the wrong var name.
+  [[ -v _autocomplete_async_fd && $_autocomplete_async_fd -ge 10 ]] &&
+    { exec {_autocomplete_async_fd}<&- } 2> /dev/null &&
     unset _autocomplete_async_fd
   unset curcontext _autocomplete__isearch
 
@@ -194,7 +194,7 @@ ${0}:precmd() {
 
   # Unhook ourselves immediately, so we don't get called more than once.
   builtin zle -F "$fd" 2> /dev/null
-  [[ -t $fd ]] && exec {fd}<&-
+  { exec {fd}<&- } 2> /dev/null  # pipe fd, never a tty — close unconditionally
 
   if [[ -n $_autocomplete__zle_flags ]]; then
     builtin zle -f $_autocomplete__zle_flags
@@ -370,7 +370,7 @@ ${0}:precmd() {
       (( SECONDS += reply[2] ))
 
     } always {
-      [[ -t $fd ]] && exec {fd}<&-
+      { exec {fd}<&- } 2> /dev/null  # pipe fd, never a tty — close unconditionally
     }
 
     [[ -n $curcontext ]] &&


### PR DESCRIPTION
## Problem

Every async completion cycle opens a pipe fd via `sysopen ... <(...)` and is
meant to close it in the fd-widget callbacks (with `:clear` as a fallback for
early ZLE exits). Two bugs made all of those closes dead code, so the fd leaked
each cycle. The fds pile up until the process hits its descriptor limit — 256 by
default on macOS, i.e. a few hundred keystrokes — after which the next redraw
fails in an unrelated consumer such as zsh-syntax-highlighting:

```
cannot duplicate fd 1: too many open files
```

That's just the messenger; the leak is in `.autocomplete__async`.

## Root causes

Both in `Functions/Init/.autocomplete__async`:

1. The closes were guarded by `[[ -t $fd ]]` (a tty test), but these fds are
   pipes from process substitution, never ttys — so the guard was always false
   and the close never ran.
2. The `:clear` fallback guarded on `$_autocomplete__async_fd` (double
   underscore), which is never assigned; the real variable is the
   single-underscore `_autocomplete_async_fd`. Always false, so it never ran either.

## Fix

Close the fd unconditionally with `{ exec {fd}<&- } 2>/dev/null` at all three
sites, and use the correct variable name in `:clear`.

## Verification

A/B pty test, identical keystrokes through async completion:

- **before:** open pipe fds climb 72 → 147 → 218 → 291, never released
- **after:** flat at 0

---

Fixes #862. Also covers the variable-name mismatch from #858, so it can
supersede that PR.
