### PR TITLE
Stop rebuilding the comp dump after dropping _autocomplete__command

### DIFF
--- a/Functions/Init/.autocomplete__compinit
+++ b/Functions/Init/.autocomplete__compinit
@@ -33,7 +33,7 @@ ${0}:precmd() {
   typeset -g \
       _comp_dumpfile=${_comp_dumpfile:-${ZSH_COMPDUMP:-${XDG_CACHE_HOME:-$HOME/.cache}/zsh/compdump}}
 
-  if [[ -v _comps[-command-] && $_comps[-command-] != _autocomplete__command ]]; then
+  if [[ -v _comps[-command-] && $_comps[-command-] != _autocd ]]; then
     zf_rm -f $_comp_dumpfile
   else
 


### PR DESCRIPTION
Follow-up to #879 (`d6e35c9`).

That change removed `Completions/_autocomplete__command`, which previously registered itself for the `-command-` context and delegated to zsh's `_autocd`.

The comp-dump invalidation guard was not updated:

```zsh
[[ -v _comps[-command-] &&
   $_comps[-command-] != _autocomplete__command ]]
```

After #879, zsh registers `_autocd` directly for `-command-`. During the first `precmd` of every new shell, the stale guard therefore treats the existing comp dump as incompatible, deletes it, and forces `compinit -d` to rescan the completion path and regenerate the dump instead of reusing it.

This updates the expected completer to `_autocd`:

```diff
-  if [[ -v _comps[-command-] && $_comps[-command-] != _autocomplete__command ]]; then
+  if [[ -v _comps[-command-] && $_comps[-command-] != _autocd ]]; then
```

The guard still invalidates dumps created with a different `-command-` completer, while accepting the completer now used after #879.

## Verification

- `_comps[-command-]` is `_autocd`.
- The existing comp dump is reused across subsequent shell starts.
- Command and OMP completion functions remain registered.
- `./run-tests.zsh`: 51 of 51 tests passed.