### PR TITLE
Create recent-dirs file's parent dir before writing to it

### DIFF
--- a/Functions/Init/.autocomplete__recent-dirs
+++ b/Functions/Init/.autocomplete__recent-dirs
@@ -6,12 +6,20 @@ ${0}:precmd() {
   setopt autopushd pushdignoredups  # Set *global* shell options.
   builtin autoload -Uz chpwd_recent_dirs chpwd_recent_filehandler
 
-  local __=
+  local __=  # Holds throwaway zstyle -s results we don't need.
   builtin zstyle -s :chpwd: recent-dirs-file __ ||
       builtin zstyle ':chpwd:*' recent-dirs-file \
           ${XDG_DATA_HOME:-$HOME/.local/share}/zsh/chpwd-recent-dirs
   builtin zstyle -s :chpwd: recent-dirs-max __ ||
       builtin zstyle ':chpwd:*' recent-dirs-max 0
+
+  # `chpwd_recent_filehandler` writes the recent-dirs file with a bare redirect
+  # and errors out if its parent dir is missing. Create it first. `zf_mkdir` is
+  # already loaded at the top of this file.
+  local recent_dirs_file=
+  builtin zstyle -s :chpwd: recent-dirs-file recent_dirs_file
+  [[ -z $recent_dirs_file || -d ${recent_dirs_file:h} ]] ||
+      zf_mkdir -p -- ${recent_dirs_file:h}
 
   local -a reply=()
   chpwd_recent_filehandler


### PR DESCRIPTION
Fixes #892. Regression of #244 (also reported as #242).

`chpwd_recent_filehandler` writes the recent-dirs file with a bare redirect, so it fails when the parent directory does not yet exist. On a fresh install `~/.local/share/zsh/` is absent, so **every `cd` prints an error** and recent-directory completion never works:

```
chpwd_recent_filehandler:29: no such file or directory: /home/user/.local/share/zsh/chpwd-recent-dirs
```

`zf_mkdir` is already loaded at the top of `.autocomplete__recent-dirs` but was never called. `.autocomplete__main` does create its own directories (`zf_mkdir -p -- $logdir`, `zf_mkdir -pm 0700 $zsh_cache_dir`); only this path was missed.

This resolves the `recent-dirs-file` zstyle first and creates *that* path's parent, so a user-supplied `zstyle ':chpwd:*' recent-dirs-file` is honoured rather than the hard-coded XDG default. It is a no-op when the directory already exists.

### Verification

Using the bug-report template, against `027cdab`:

**Before**
```zsh
$ cd $(mktemp -d)
$ unset _comp_dumpfile ZDOTDIR XDG_CACHE_HOME XDG_CONFIG_HOME XDG_DATA_HOME
$ HOME=$PWD exec zsh -f
% source /path/to/zsh-autocomplete/zsh-autocomplete.plugin.zsh
% cd /
chpwd_recent_filehandler:29: no such file or directory: /tmp/za-repro/.local/share/zsh/chpwd-recent-dirs
```

**After** — same steps, no error, and the file is written correctly:
```zsh
% cd / ; cd /tmp
% cat ~/.local/share/zsh/chpwd-recent-dirs
$'/tmp'
$'/'
```

Also verified with a nonexistent two-level `XDG_DATA_HOME`, confirming `-p` creates the full path.
